### PR TITLE
Syntax correction (missing semi-colon)

### DIFF
--- a/koala.cow
+++ b/koala.cow
@@ -1,7 +1,7 @@
 ##
 ## From the canonical koala collection
 ##
-$eye = chop($eyes)
+$eye = chop($eyes);
 $the_cow = <<EOC;
   $thoughts
    $thoughts


### PR DESCRIPTION
When running `cowsay -f koala xxx`, on Ubuntu 16.04, I got the following error:

> Scalar found where operator expected at /path/to/cowsay/koala.cow line 5, near ")
> $the_cow"
>        (Missing semicolon on previous line?)
> cowsay: syntax error at /path/to/cowsay/koala.cow line 5, near ")
> $the_cow "

This is the only offending file with an issue, I think ...